### PR TITLE
Refactor activities to return non-None

### DIFF
--- a/Test-F1/__init__.py
+++ b/Test-F1/__init__.py
@@ -42,4 +42,4 @@ def main(orchestratorActivityTrigger, outputDocument: func.Out[func.Document]) -
 
     outputDocument.set(func.Document.from_dict(result1))
 
-    return
+    return ""

--- a/Test-F2/__init__.py
+++ b/Test-F2/__init__.py
@@ -27,6 +27,6 @@ def main(F1activitytrigger, inputDocument: func.DocumentList) -> str:
 
     result2 = inputDocument[0].data
 
-    result2['username'] = add_username() 
+    result2['username'] = add_username()
 
     return result2

--- a/Test-F3/__init__.py
+++ b/Test-F3/__init__.py
@@ -22,10 +22,10 @@ def add_date(string=None):
 
 def main(F2activitytrigger, orchestrationResult2, outputDocument: func.Out[func.Document]) -> str:
 
-    result3 = orchestrationResult2.copy()
+    result3 = F2activitytrigger.copy()
 
     result3['timestamp'] = add_date()
 
     outputDocument.set(func.Document.from_dict(result3))
 
-    return
+    return ""


### PR DESCRIPTION
As discussed, a current limitation of Durable Functions for Python (Durable Python for short) is that activities need to return a non-None value. For safety, I'm returning `""`.

I tested this with a local storage emulator, so I changed your `AzureWebJobsStorage` value to be different, but did not commit that change since I figured you want to keep your connection string. Please let me know if this fixes the exceptions your were seeing, it did so for me ⚡ !